### PR TITLE
Fix for ESP32 C6

### DIFF
--- a/.github/workflows/build_pages.yml
+++ b/.github/workflows/build_pages.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Firmware and Pages
 
 on:
   workflow_dispatch:

--- a/boards/m5stack-nanoc6.yml
+++ b/boards/m5stack-nanoc6.yml
@@ -2,6 +2,8 @@ substitutions:
   board: esp32-c6-devkitm-1
   variant: esp32c6
   flash_size: 4MB
+  espidf_version: "5.3.1"
+  platformio_version: "6.9.0"
 
 esp32:
   framework:

--- a/packages/board.yml
+++ b/packages/board.yml
@@ -1,6 +1,12 @@
+defaults:
+  espidf_version: recommended
+  platformio_version: recommended
+
 esp32:
   board: ${board}
   variant: ${variant}
   flash_size: ${flash_size}
   framework:
     type: esp-idf
+    version: ${espidf_version}
+    platform_version: ${platformio_version}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Workflow Updates**
  - Renamed GitHub Actions workflow to "Build Firmware and Pages"
  - Enhanced build process for firmware across multiple configurations

- **Board Configuration**
  - Added default settings for ESP32 board configurations
  - Specified recommended versions for ESP-IDF and PlatformIO frameworks

- **Infrastructure Improvements**
  - Refined GitHub Pages deployment process
  - Updated build and deployment conditions for more precise control
<!-- end of auto-generated comment: release notes by coderabbit.ai -->